### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ setup(name="pyutils",
       version="0.1",
       description="Test for pip install git+",
       url="https://github.com/kylemcdonald/python-utils",
-      install_requires=["numpy", "python-opencv", "Pillow"],
+      install_requires=["numpy", "opencv-python", "Pillow"],
       packages=find_packages()
 )


### PR DESCRIPTION
I think the package name for the python wrapper of opencv is switched. I wasn't able to install your package until I switched the naming